### PR TITLE
Support constructed stylesheets in shadow DOM instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,16 @@
 
 rrweb refers to 'record and replay the web', which is a tool for recording and replaying users' interactions on the web.
 
+## Publishing @chromaui/rrweb-snapshot
+
+Chromatic maintains this fork of `rrweb-io/rrweb` solely to publish a version of `rrweb-snapshot` that supports constructable stylesheets for Chromatic e2e capture purposes.
+
+To distinguish Chromatic-specific builds from those coming from rrweb-io, a `-noAbsolute` label is appended to the end of the package version. If more than one Chromatic build is produced based off of the same rrweb-io version, a number is appended to the end of that label (e.g. `2.0.0-alpha.17-noAbsolute.1`).
+
+1. In `packages/rrweb-snapshot/package.json`, set the appropriate `-noAbsolute.X` version
+2. CD to `packages/rrweb-snapshot`
+3. Run `npm publish`
+
 ## Guide
 
 [**📚 Read the rrweb guide here. 📚**](./guide.md)

--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "rrweb-snapshot",
-  "version": "2.0.0-alpha.17",
+  "name": "@chromaui/rrweb-snapshot",
+  "version": "2.0.0-alpha.17-noAbsolute",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",
@@ -12,7 +12,7 @@
     "test:update": "yarn build && vitest run --update",
     "bench": "vite build && vitest bench",
     "dev": "vite build --watch",
-    "build": "yarn turbo prepublish -F rrweb-snapshot",
+    "build": "yarn turbo prepublish -F @chromaui/rrweb-snapshot",
     "check-types": "tsc --noEmit",
     "prepublish": "yarn check-types && vite build",
     "lint": "yarn eslint src"
@@ -20,7 +20,7 @@
   "type": "module",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/rrweb-io/rrweb.git"
+    "url": "git+https://github.com/chromaui/rrweb.git"
   },
   "keywords": [
     "rrweb",
@@ -50,9 +50,9 @@
   "author": "yanzhen@smartx.com",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/rrweb-io/rrweb/issues"
+    "url": "https://github.com/chromaui/rrweb/issues"
   },
-  "homepage": "https://github.com/rrweb-io/rrweb/tree/master/packages/rrweb-snapshot#readme",
+  "homepage": "https://github.com/chromaui/rrweb/tree/master/packages/rrweb-snapshot#readme",
   "devDependencies": {
     "@rrweb/utils": "^2.0.0-alpha.17",
     "@types/jsdom": "^20.0.0",

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -152,7 +152,7 @@ export function buildStyleNode(
 }
 
 function buildNode(
-  n: serializedNodeWithId,
+  n: serializedNodeWithId & { chromaticAdoptedStylesheets?: string[] },
   options: {
     doc: Document;
     hackCss: boolean;
@@ -380,13 +380,9 @@ function buildNode(
          */
         if (!node.shadowRoot) {
           node.attachShadow({ mode: 'open' });
-          // @ts-expect-error TODO
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-          n.chromaticAdoptedStylesheets.forEach(
-            // @ts-expect-error TODO
+          n.chromaticAdoptedStylesheets?.forEach(
             (chromaticAdoptedStylesheet) => {
               const styleSheet = new CSSStyleSheet();
-              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
               styleSheet.replaceSync(chromaticAdoptedStylesheet);
               node.shadowRoot?.adoptedStyleSheets.push(styleSheet);
             },

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -380,6 +380,17 @@ function buildNode(
          */
         if (!node.shadowRoot) {
           node.attachShadow({ mode: 'open' });
+          // @ts-expect-error TODO
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+          n.chromaticAdoptedStylesheets.forEach(
+            // @ts-expect-error TODO
+            (chromaticAdoptedStylesheet) => {
+              const styleSheet = new CSSStyleSheet();
+              // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+              styleSheet.replaceSync(chromaticAdoptedStylesheet);
+              node.shadowRoot?.adoptedStyleSheets.push(styleSheet);
+            },
+          );
         } else {
           while (node.shadowRoot.firstChild) {
             node.shadowRoot.removeChild(node.shadowRoot.firstChild);
@@ -443,6 +454,18 @@ export function buildNodeWithSN(
   if (!node) {
     return null;
   }
+  // // @ts-expect-error TODO
+  // if (n.chromaticAdoptedStylesheets) {
+  //   // @ts-expect-error TODO
+  //   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  //   n.chromaticAdoptedStylesheets.forEach((sheet) => {
+  //     const styleSheet = new CSSStyleSheet();
+  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  //     styleSheet.replaceSync(sheet);
+  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  //     doc.adoptedStyleSheets.push(styleSheet);
+  //   });
+  // }
   // If the snapshot is created by checkout, the rootId doesn't change but the iframe's document can be changed automatically when a new iframe element is created.
   if (n.rootId && (mirror.getNode(n.rootId) as Document) !== doc) {
     mirror.replace(n.rootId, doc);

--- a/packages/rrweb-snapshot/src/rebuild.ts
+++ b/packages/rrweb-snapshot/src/rebuild.ts
@@ -450,18 +450,6 @@ export function buildNodeWithSN(
   if (!node) {
     return null;
   }
-  // // @ts-expect-error TODO
-  // if (n.chromaticAdoptedStylesheets) {
-  //   // @ts-expect-error TODO
-  //   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  //   n.chromaticAdoptedStylesheets.forEach((sheet) => {
-  //     const styleSheet = new CSSStyleSheet();
-  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-  //     styleSheet.replaceSync(sheet);
-  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  //     doc.adoptedStyleSheets.push(styleSheet);
-  //   });
-  // }
   // If the snapshot is created by checkout, the rootId doesn't change but the iframe's document can be changed automatically when a new iframe element is created.
   if (n.rootId && (mirror.getNode(n.rootId) as Document) !== doc) {
     mirror.replace(n.rootId, doc);

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1020,13 +1020,41 @@ export function serializeNodeWithId(
     onSerialize(n);
   }
   let recordChild = !skipChild;
+  // @ts-expect-error TODO
+  if (n.adoptedStyleSheets) {
+    // @ts-expect-error TODO
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    serializedNode.chromaticAdoptedStylesheets =
+      // @ts-expect-error TODO
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      n.adoptedStyleSheets.map(
+        // @ts-expect-error TODO
+        (sheet) =>
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+          Array.from(sheet.cssRules)
+            // @ts-expect-error TODO
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+            .map((rule) => rule.cssText)
+            .join(' '),
+      );
+  }
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;
     // this property was not needed in replay side
     delete serializedNode.needBlock;
     const shadowRootEl = dom.shadowRoot(n);
-    if (shadowRootEl && isNativeShadowDom(shadowRootEl))
+    if (shadowRootEl && isNativeShadowDom(shadowRootEl)) {
       serializedNode.isShadowHost = true;
+      if (shadowRootEl.adoptedStyleSheets) {
+        // @ts-expect-error TODO
+        serializedNode.chromaticAdoptedStylesheets =
+          shadowRootEl.adoptedStyleSheets.map((sheet) =>
+            Array.from(sheet.cssRules)
+              .map((rule) => rule.cssText)
+              .join(' '),
+          );
+      }
+    }
   }
   if (
     (serializedNode.type === NodeType.Document ||

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1030,7 +1030,7 @@ export function serializeNodeWithId(
     const shadowRootEl = dom.shadowRoot(n);
     if (shadowRootEl && isNativeShadowDom(shadowRootEl)) {
       serializedNode.isShadowHost = true;
-      if (shadowRootEl.adoptedStyleSheets) {
+      if (shadowRootEl.adoptedStyleSheets.length > 0) {
         serializedNode.chromaticAdoptedStylesheets =
           shadowRootEl.adoptedStyleSheets.map((stylesheet) =>
             stringifyStylesheet(stylesheet),

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1023,23 +1023,19 @@ export function serializeNodeWithId(
     onSerialize(n);
   }
   let recordChild = !skipChild;
-  // @ts-expect-error TODO
-  if (n.adoptedStyleSheets) {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-    serializedNode.chromaticAdoptedStylesheets =
-      // @ts-expect-error TODO
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-      n.adoptedStyleSheets.map(
-        // @ts-expect-error TODO
-        (sheet) =>
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-          Array.from(sheet.cssRules)
-            // @ts-expect-error TODO
-            // eslint-disable-next-line @typescript-eslint/no-unsafe-return
-            .map((rule) => rule.cssText)
-            .join(' '),
-      );
-  }
+  // // @ts-expect-error TODO
+  // if (n.adoptedStyleSheets) {
+  //   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  //   serializedNode.chromaticAdoptedStylesheets =
+  //     // @ts-expect-error TODO
+  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+  //     n.adoptedStyleSheets.map(
+  //       // @ts-expect-error TODO
+  //       (stylesheet) =>
+  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
+  //         stringifyStylesheet(stylesheet),
+  //     );
+  // }
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;
     // this property was not needed in replay side

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1023,19 +1023,6 @@ export function serializeNodeWithId(
     onSerialize(n);
   }
   let recordChild = !skipChild;
-  // // @ts-expect-error TODO
-  // if (n.adoptedStyleSheets) {
-  //   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  //   serializedNode.chromaticAdoptedStylesheets =
-  //     // @ts-expect-error TODO
-  //     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-  //     n.adoptedStyleSheets.map(
-  //       // @ts-expect-error TODO
-  //       (stylesheet) =>
-  //         // eslint-disable-next-line @typescript-eslint/no-unsafe-argument, @typescript-eslint/no-unsafe-member-access
-  //         stringifyStylesheet(stylesheet),
-  //     );
-  // }
   if (serializedNode.type === NodeType.Element) {
     recordChild = recordChild && !serializedNode.needBlock;
     // this property was not needed in replay side

--- a/packages/rrweb-snapshot/src/snapshot.ts
+++ b/packages/rrweb-snapshot/src/snapshot.ts
@@ -1008,7 +1008,10 @@ export function serializeNodeWithId(
     id = genId();
   }
 
-  const serializedNode = Object.assign(_serializedNode, { id });
+  const serializedNode: serializedNode & {
+    id: number;
+    chromaticAdoptedStylesheets?: Array<string | null>;
+  } = Object.assign(_serializedNode, { id });
   // add IGNORED_NODE to mirror to track nextSiblings
   mirror.add(n, serializedNode);
 
@@ -1022,7 +1025,6 @@ export function serializeNodeWithId(
   let recordChild = !skipChild;
   // @ts-expect-error TODO
   if (n.adoptedStyleSheets) {
-    // @ts-expect-error TODO
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     serializedNode.chromaticAdoptedStylesheets =
       // @ts-expect-error TODO
@@ -1046,12 +1048,9 @@ export function serializeNodeWithId(
     if (shadowRootEl && isNativeShadowDom(shadowRootEl)) {
       serializedNode.isShadowHost = true;
       if (shadowRootEl.adoptedStyleSheets) {
-        // @ts-expect-error TODO
         serializedNode.chromaticAdoptedStylesheets =
-          shadowRootEl.adoptedStyleSheets.map((sheet) =>
-            Array.from(sheet.cssRules)
-              .map((rule) => rule.cssText)
-              .join(' '),
+          shadowRootEl.adoptedStyleSheets.map((stylesheet) =>
+            stringifyStylesheet(stylesheet),
           );
       }
     }

--- a/packages/rrweb/src/record/mutation.ts
+++ b/packages/rrweb/src/record/mutation.ts
@@ -349,6 +349,8 @@ export default class MutationBuffer {
         onStylesheetLoad: (link, childSn) => {
           this.stylesheetManager.attachLinkElement(link, childSn);
         },
+        // @ts-expect-error cssCaptured isn't specified as an accepted property,
+        // but we didn't touch anything near here, so ignoring for now
         cssCaptured,
       });
       if (sn) {

--- a/packages/rrweb/test/__snapshots__/record.test.ts.snap
+++ b/packages/rrweb/test/__snapshots__/record.test.ts.snap
@@ -628,7 +628,10 @@ exports[`record > captures adopted stylesheets in nested shadow doms and iframes
                         \\"childNodes\\": [],
                         \\"rootId\\": 29,
                         \\"id\\": 33,
-                        \\"isShadowHost\\": true
+                        \\"isShadowHost\\": true,
+                        \\"chromaticAdoptedStylesheets\\": [
+                          \\"div { font-size: large; }\\"
+                        ]
                       }
                     ],
                     \\"rootId\\": 29,
@@ -849,7 +852,11 @@ exports[`record > captures adopted stylesheets in shadow doms and iframe 1`] = `
                       }
                     ],
                     \\"id\\": 10,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"chromaticAdoptedStylesheets\\": [
+                      \\"div { color: yellow; }h2 { color: orange; }h3 { font-size: larger; }\\",
+                      \\"span { color: red; }\\"
+                    ]
                   },
                   {
                     \\"type\\": 3,
@@ -1204,7 +1211,10 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
                       }
                     ],
                     \\"id\\": 7,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"chromaticAdoptedStylesheets\\": [
+                      \\"h1 { color: blue; }\\"
+                    ]
                   },
                   {
                     \\"type\\": 3,
@@ -1304,7 +1314,10 @@ exports[`record > captures adopted stylesheets of shadow doms in checkout full s
                       }
                     ],
                     \\"id\\": 7,
-                    \\"isShadowHost\\": true
+                    \\"isShadowHost\\": true,
+                    \\"chromaticAdoptedStylesheets\\": [
+                      \\"h1 { color: blue; }\\"
+                    ]
                   },
                   {
                     \\"type\\": 3,


### PR DESCRIPTION
Detect, serialize, and rebuild constructed stylesheets in shadow DOM elements.

## QA

1. Go to `packages/rrweb-snapshot`
2. Run `yarn build`
3. Run `yarn link` to set this package up for local linking
4. In the chromatic-e2e repo, use the locally-linked rrweb-snapshot build in the cypress, playwright, and shared packages by replacing `"@chromaui/rrweb-snapshot": "2.0.0-alpha.17"` with `"@chromaui/rrweb-snapshot": "link:../../../rrweb/packages/rrweb-snapshot"` in each package.json
5. Run `yarn test:playwright && yarn archive-storybook:playwright ` to launch the built Storybook
6. Verify that the `styles render in shadow DOM elements` and `styles render in web components in shadow DOM` stories properly display the color styles that are described by the text on those story pages
7. ~~Repeat steps 5 & 6 for cypress~~ I tried this but Cypress didn't seem to like the local link, so we will need to verify this after we publish a version of this package