### PR TITLE
fix(snapshot): transform more css pseudo states

### DIFF
--- a/packages/rrweb-snapshot/package.json
+++ b/packages/rrweb-snapshot/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@chromaui/rrweb-snapshot",
-  "version": "2.0.0-alpha.18-noAbsolute",
+  "version": "2.0.0-alpha.19-noAbsolute",
   "description": "rrweb's component to take a snapshot of DOM, aka DOM serializer",
   "scripts": {
     "prepare": "npm run prepack",

--- a/packages/rrweb-snapshot/src/css.ts
+++ b/packages/rrweb-snapshot/src/css.ts
@@ -32,6 +32,21 @@ const pseudoClassPlugin: AcceptedPlugin = {
           if (selector.includes(':hover')) {
             rule.selector += ',\n' + selector.replace(/:hover/g, '.\\:hover');
           }
+          if (selector.includes(':active')) {
+            rule.selector += ',\n' + selector.replace(/:active/g, '.\\:active');
+          }
+          if (selector.includes(':focus-visible')) {
+            rule.selector +=
+              ',\n' + selector.replace(/:focus-visible/g, '.\\:focus-visible');
+          }
+          if (selector.includes(':focus-within')) {
+            rule.selector +=
+              ',\n' + selector.replace(/:focus-within/g, '.\\:focus-within');
+          }
+          if (/:focus(?![-\w])/.test(selector)) {
+            rule.selector +=
+              ',\n' + selector.replace(/:focus(?![-\w])/g, '.\\:focus');
+          }
         });
       },
     };


### PR DESCRIPTION
Adds more CSS pseudo states to be transformed when `snapshot` and `rebuild` are called.

Thanks to @hi-ogawa for finding this bug/lack-of-feature in `rrweb-snapshot` 🙌 

## How to test

See instructions in https://github.com/chromaui/chromatic-e2e/pull/323.

https://github.com/user-attachments/assets/b92c8b0f-8137-4c5f-a19a-afbde5ac666a


